### PR TITLE
Remove surplus bracket from authority_references_list.php

### DIFF
--- a/themes/default/views/bundles/authority_references_list.php
+++ b/themes/default/views/bundles/authority_references_list.php
@@ -76,7 +76,7 @@
 				
 					if (!($vs_template = caGetOption("{$vs_ref_table_name}_displayTemplate", $va_settings, null))) {
 						$vs_template = $t_instance->getAppConfig()->get("{$vs_ref_table_name}_lookup_settings");
-						if(!is_array($vs_template) && $vs_template)) {
+						if(!is_array($vs_template) && $vs_template) {
 							$vs_template = [$vs_template];
 						}
 						if (is_array($vs_template)) {


### PR DESCRIPTION
The '))' on line 79 resulted in:
```
FastCGI sent in stderr: "PHP message: PHP Parse error:  Unclosed '{' on line 77 does not match ')'
```